### PR TITLE
Add transformation service

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,6 +154,18 @@
               </div>
               <div class="timeline-item">
                 <div class="timeline-marker is-icon is-link">
+                  <i class="fa fa-recycle"></i>
+                </div>
+                <div class="timeline-content">
+                  <p class="heading">Transform</p>
+                  <p>
+                    Everyone has a legacy. Together we will review your existing
+                    applications and get them ready for the cloud.
+                  </p>
+                </div>
+              </div>
+              <div class="timeline-item">
+                <div class="timeline-marker is-icon is-link">
                   <i class="fa fa-pencil-alt"></i>
                 </div>
                 <div class="timeline-content">

--- a/index.html
+++ b/index.html
@@ -133,10 +133,10 @@
           <h3 class="title is-2 is-spaced">Our Services</h3>
           <p>
             No matter whether you are embarking on a new endeavour, reworking an
-            existing idea or transforming your legacy applications, we work
-            hands-on with your team in every iteration of your project. Here are
-            some of the services we offer. If the one you require is not on the
-            list, let us know! We're always happy to innovate.
+            idea or transforming your existing applications, we work hands-on
+            with your team in every iteration of your project. Here are some of
+            the services we offer. If the one you require is not on the list,
+            let us know! We're always happy to innovate.
           </p>
           <div class="content" style="margin-top:4rem;">
             <div class="timeline is-centered">
@@ -159,8 +159,8 @@
                 <div class="timeline-content">
                   <p class="heading">Transform</p>
                   <p>
-                    Everyone has a legacy. Together we will review your existing
-                    applications and get them ready for the cloud.
+                    Everyone has a history. Together we will review your
+                    existing applications and get them ready for the cloud.
                   </p>
                 </div>
               </div>

--- a/index.html
+++ b/index.html
@@ -132,11 +132,11 @@
         <div class="column is-half">
           <h3 class="title is-2 is-spaced">Our Services</h3>
           <p>
-            No matter whether you are embarking on a new endeavour or reworking
-            an existing idea, we work hands-on with your team in every iteration
-            of your project. Here are some of the services we offer. If the one
-            you require is not on the list, let us know! We're always happy to
-            innovate.
+            No matter whether you are embarking on a new endeavour, reworking an
+            existing idea or transforming your legacy applications, we work
+            hands-on with your team in every iteration of your project. Here are
+            some of the services we offer. If the one you require is not on the
+            list, let us know! We're always happy to innovate.
           </p>
           <div class="content" style="margin-top:4rem;">
             <div class="timeline is-centered">

--- a/index.html
+++ b/index.html
@@ -429,9 +429,9 @@
           <p>
             We are cloud-native software engineers with experience in both the
             corporate and the startup world. We pride ourselves in being expert
-            consultants, competent coaches and seasoned hackers at the same
-            time. Interested in meeting us? Feel free to approach us on social
-            media or at a meetup near you!
+            consultants, competent coaches and seasoned coders at the same time.
+            Interested in meeting us? Feel free to approach us on social media
+            or at a meetup near you!
           </p>
           <div class="content" style="margin-top:4rem;">
             <div class="tile is-ancestor">


### PR DESCRIPTION
I propose to explicitely mention an additional service: transforming legacy applications into cloud-native ones. I think this is important for attracting the corresponding business, of which there is a lot. Otherwise, people might perceive us as purely green-field development oriented.

We can do this by mentioning it in the Services text or putting an extra item on the timeline or both.

I have also included a change from the work _hacker_ to the word _coder_ in this PR. I think the word _hacker_ could confuse some less technically oriented customers, who might think we are talking about security hacking.