### PR TITLE
drop the second line in the title, make it simpler

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,10 +53,7 @@
               <h1 class="title is-1 is-spaced">
                 be<span class="is-blinking">|</span>spin
               </h1>
-              <h2 class="subtitle is-4">
-                Cloud Native Citizens <br />
-                Down To Earth
-              </h2>
+              <h2 class="subtitle is-4">Cloud Native Citizens</h2>
             </div>
             <div class="column is-offset-4-desktop has-text-centered">
               <img src="img/cloudcity.svg" class="cloud-city" />


### PR DESCRIPTION
I think we should drop the "Down to Earth" part from the title. Just having "Cloud Native Citizens" looks and sounds cooler in my opinion.